### PR TITLE
Make it async

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -1,23 +1,27 @@
 import logging
 from os import getenv
-from time import sleep
 from wsgiref.simple_server import make_server
+import time, traceback, threading
+
 
 from flask import Flask
-from prometheus_client import make_wsgi_app, start_http_server
 from prometheus_client.core import REGISTRY
+from prometheus_client import make_wsgi_app, start_http_server, write_to_textfile
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.serving import run_simple
 
 from helpers.prometheus import SentryCollector, clean_registry
 from libs.sentry import SentryAPI
 
+
 DEFAULT_BASE_URL = "https://sentry.io/api/0/"
 BASE_URL = getenv("SENTRY_BASE_URL") or DEFAULT_BASE_URL
 AUTH_TOKEN = getenv("SENTRY_AUTH_TOKEN")
 ORG_SLUG = getenv("SENTRY_EXPORTER_ORG")
 PROJECTS_SLUG = getenv("SENTRY_EXPORTER_PROJECTS")
-LOG_LEVEL = getenv("LOG_LEVEL", "INFO")
+LOG_LEVEL = getenv("LOG_LEVEL", "DEBUG")
+QUERY_SENTRY_EVERY_SECONDS = int(getenv("QUERY_SENTRY_EVERY_SECONDS", "300"))
+METRICS_FILE = '/tmp/sentry.prom'
 
 log = logging.getLogger("exporter")
 level = logging.getLevelName(LOG_LEVEL)
@@ -28,6 +32,17 @@ logging.basicConfig(
 
 app = Flask(__name__)
 
+
+def every(delay, task):
+  next_time = time.time() + delay
+  while True:
+    time.sleep(max(0, next_time - time.time()))
+    try:
+      task()
+    except Exception as e:
+      traceback.print_exc()
+      log.exception(f"Problem while executing repetitive task: {e}")
+    next_time += (time.time() - next_time) // delay * delay + delay
 
 def get_metric_config():
     """Get metric scraping options."""
@@ -52,15 +67,23 @@ def hello_world():
     <h3>Go to <a href=/metrics/>/metrics</a></h3>\
     "
 
-
-@app.route("/metrics/")
-def sentry_exporter():
+def collect_metrics():
     sentry = SentryAPI(BASE_URL, AUTH_TOKEN)
     log.info("exporter: cleaning registry collectors...")
     clean_registry()
     REGISTRY.register(SentryCollector(sentry, ORG_SLUG, get_metric_config(), PROJECTS_SLUG))
-    exporter = DispatcherMiddleware(app.wsgi_app, {"/metrics": make_wsgi_app()})
-    return exporter
+    write_to_textfile(METRICS_FILE, REGISTRY)
+
+@app.route("/metrics/")
+def return_metrics():
+    try:
+        with open(METRICS_FILE) as file:
+            return(file.read(), 200)
+    except Exception as e:
+        log.debug("Metrics file missing! Returning empty response")
+        return('', 204)
+        # exporter = DispatcherMiddleware(app.wsgi_app, {"/metrics": make_wsgi_app()})
+        # return exporter
 
 
 if __name__ == "__main__":
@@ -69,7 +92,12 @@ if __name__ == "__main__":
         log.error("ENVs: SENTRY_AUTH_TOKEN or SENTRY_EXPORTER_ORG was not found!")
         exit(1)
 
+
+    threading.Thread(target=lambda: collect_metrics()).start()
+    threading.Thread(target=lambda: every(QUERY_SENTRY_EVERY_SECONDS, collect_metrics)).start()
+
     log.info("Starting simple wsgi server...")
     # The binding port was picked from the Default port allocations documentation:
     # https://github.com/prometheus/prometheus/wiki/Default-port-allocations
     run_simple(hostname="0.0.0.0", port=9790, application=app.wsgi_app)
+


### PR DESCRIPTION
Main changes:

- Execute the metrics retrieval without blocking the main thread and every X configurable seconds
- Disable caching projects and issues to a JSON file, cache in memory instead
- The registry exports the metrics to a file
- The /metrics endpoint returns the contents of that file or an empty reponse